### PR TITLE
Fix a problem with VSCode rust-analyzer extension

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.checkOnSave.extraArgs": [
+        "--target",
+        "riscv32imc-unknown-none-elf"
+    ]
+}


### PR DESCRIPTION
You need to specify the target platform or you get some errors.

https://github.com/rust-lang/rust-analyzer/issues/3801